### PR TITLE
add airport migration with early timestamp

### DIFF
--- a/db/migrate/20220818182224_create_airports.rb
+++ b/db/migrate/20220818182224_create_airports.rb
@@ -1,0 +1,10 @@
+class CreateAirports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :airports do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220823184214_add_column_to_airport.rb
+++ b/db/migrate/20220823184214_add_column_to_airport.rb
@@ -1,6 +1,0 @@
-class AddColumnToAirport < ActiveRecord::Migration[7.0]
-
-  def change
-    add_column :airports, :code, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,11 +43,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_27_131251) do
   end
 
   create_table "airports", force: :cascade do |t|
-    t.string "code"
     t.bigint "location_id", null: false
+    t.string "code"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
     t.index ["location_id"], name: "index_airports_on_location_id"
   end
 
@@ -64,11 +64,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_27_131251) do
   create_table "flights", force: :cascade do |t|
     t.datetime "departure_time"
     t.datetime "arrival_time"
+    t.bigint "departure_airport_id"
+    t.bigint "arrival_airport_id"
     t.string "flight_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "departure_airport_id"
-    t.bigint "arrival_airport_id"
     t.index ["arrival_airport_id"], name: "index_flights_on_arrival_airport_id"
     t.index ["departure_airport_id"], name: "index_flights_on_departure_airport_id"
   end
@@ -168,8 +168,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_27_131251) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "airports", "locations"
   add_foreign_key "bookings", "passenger_groups"
-  add_foreign_key "flights", "locations", column: "arrival_airport_id"
-  add_foreign_key "flights", "locations", column: "departure_airport_id"
+  add_foreign_key "flights", "airports", column: "arrival_airport_id"
+  add_foreign_key "flights", "airports", column: "departure_airport_id"
   add_foreign_key "images", "locations"
   add_foreign_key "itineraries", "locations", column: "destination_id"
   add_foreign_key "passenger_groups", "itineraries"


### PR DESCRIPTION
- added migration file for aiports. Deleted a later migration to add code column to airport because is already included in the new migration file.

- changed migration file timestamp to an earlier time to fix migration timeline