### PR TITLE
adding back migration file and extending seed

### DIFF
--- a/db/migrate/20220823184214_add_column_to_airport.rb
+++ b/db/migrate/20220823184214_add_column_to_airport.rb
@@ -1,0 +1,5 @@
+class AddColumnToAirport < ActiveRecord::Migration[7.0]
+  def change
+    add_column :airports, :code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,10 +44,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_27_131251) do
 
   create_table "airports", force: :cascade do |t|
     t.bigint "location_id", null: false
-    t.string "code"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code"
     t.index ["location_id"], name: "index_airports_on_location_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,8 +77,28 @@ searches = [{"origin_city1"=>"London",
   "adults1"=>"4",
   "children1"=>"2",
   "start_date"=>"2022-10-16",
-  "end_date"=>"2022-10-22"}
-]
+  "end_date"=>"2022-10-22"},
+  {"origin_city1"=>"Zurich",
+    "adults1"=>"2",
+    "children1"=>"0",
+    "start_date"=>"2022-10-16",
+    "end_date"=>"2022-10-22"},
+    {"origin_city1"=>"London",
+      "adults1"=>"1",
+      "children1"=>"0",
+      "start_date"=>"2022-10-16",
+      "end_date"=>"2022-10-22"},
+     {"origin_city1"=>"Paris",
+      "adults1"=>"1",
+      "children1"=>"0",
+      "start_date"=>"2022-10-16",
+      "end_date"=>"2022-10-22"},
+      {"origin_city1"=>"Zurich",
+        "adults1"=>"1",
+        "children1"=>"0",
+        "start_date"=>"2022-10-16",
+        "end_date"=>"2022-10-22"}]
+
 
   i = ItinerariesController.new
   searches.each do |params|


### PR DESCRIPTION
- Adding back the missing 'add column to airports' migration file
- adding more seeding for the demo, as we'll need to reseed the database (as the airports migration file was added, it won't let us proceed without running db:migrate. but that will fail as we already have an airports model UNLESS we drop and recreate the database)
- I'll push this one directly as it's not about code, just database mgt