### PR TITLE
add form target for api search method in landing page

### DIFF
--- a/app/views/itineraries/_small_search_form.html.erb
+++ b/app/views/itineraries/_small_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag itineraries_path, :method => :get, data: {controller: "search-form", action: "click->search-form#updateButton input->search-form#updateButton"} do %>
+<%= form_tag itineraries_path, :method => :get, data: {controller: "search-form", search_form_target: "form", action: "click->search-form#updateButton input->search-form#updateButton"} do %>
   <div class="card h-100 shadow">
     <div class="collapse show">
       <div class="card-body">


### PR DESCRIPTION
the ajax search stimulus controller requires  form target; this was missing for the implementaion on the landing page, so the landing page search wasn't working. 

I have now added the data target named 'form' to the landing page. 