### PR TITLE
Remove repeating delete itinerary link

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -21,6 +21,10 @@ $headers-font: "Nunito", "Helvetica", "sans-serif";
 .text-sm {
   font-size: 12px;
 }
+
+.text-xsm {
+  font-size: 10px;
+}
 // To use a font file (.woff) uncomment following lines
 // @font-face {
 //   font-family: "Font Name";

--- a/app/views/users/sessions/_single_trip_info.html.erb
+++ b/app/views/users/sessions/_single_trip_info.html.erb
@@ -3,7 +3,7 @@
 
 <% PassengerGroup.order_by_flight_info(itinerary.passenger_groups).each do |group| %>
 
-  <div class="card-overview-info mb-3">
+  <div class="card-overview-info mt-3">
     <div class="border-bottom border-success origin-city d-flex justify-content-between align-items-bottom">
       <div>Travellers from <span class="text-primary"><strong><%= group.origin_city.city %></strong></span></div>
       <div>
@@ -21,11 +21,15 @@
       <%= render 'shared/collapsible_section', section_title: 'Getting there', section_partial: 'users/sessions/flight_leg', section_partial_params: { flights: info.first.offer["flights_there"], status: "confirmed" }, collapsed: true, bg_collapsed: 'bg-primary', bg_open: 'bg-secondary', p_x: 'p-0' %>
       <%= render 'shared/collapsible_section', section_title: 'Coming home', section_partial: 'users/sessions/flight_leg', section_partial_params: { flights: info.first.offer["flights_return"], status: "confirmed" }, collapsed: true, text_collapsed: 'text-primary', bg_collapsed: 'border border-primary', text_open: 'text-white', bg_open: 'bg-secondary', p_x: 'p-0' %>
     <% end %>
-    <div class="d-flex justify-content-between">
-      <%= link_to itinerary_path(itinerary), class: "btn btn-link text-secondary text-decoration-none" do %>
+    <div class="d-flex justify-content-between border-bottom">
+      <%= link_to itinerary_path(itinerary), class: "p-0 m-0 w-100 text-end text-xsm btn btn-link text-secondary text-decoration-none" do %>
         <i class="fas fa-search"></i> <%= info.empty? ? "Choose flights" : "Change flights" %>
       <% end %>
-      <% if owner %>
+    </div>
+  </div>
+<% end %>
+<div class="text-start">
+ <% if owner %>
         <%= link_to itinerary_path(itinerary), data: { turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-link text-secondary text-decoration-none" do %>
           <i class="fas fa-ban"></i> Delete itinerary
         <% end %>
@@ -33,8 +37,5 @@
         <%= link_to permission_path(permission), data: { turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-link text-secondary text-decoration-none" do %>
           <i class="fas fa-ban"></i> Remove itinerary
         <% end %>
-      <% end %>
-    </div>
-
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,7 +18,7 @@
                   <div class="w-100 d-flex align-items-center" data-action="click->render-itinerary-in-user-show-page#renderItineraryPartial">
                     <div><%= "Trip to #{itinerary.destination.city}" %></div>
                     <% if Permission.find_by(user: current_user, itinerary: itinerary).role == "guest" %>
-                      <div class="text-sm p-1 rounded bg-primary text-white">Shared with you</div>
+                      <div class="ms-3 text-sm p-1 rounded bg-primary text-white">Shared with you</div>
                     <% end %>
                   </div>
               <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,7 @@
               <div class="d-none itinerary">
                 <%=itinerary.id%>
               </div>
-              <%= render 'shared/collapsible_section', section_partial: 'users/sessions/single_trip_info', section_partial_params: { itinerary: itinerary }, collapsed: collapsed, clickable_header: true do %>
+              <%= render 'shared/collapsible_section', section_partial: 'users/sessions/single_trip_info', section_partial_params: { itinerary: itinerary }, collapsed: collapsed, clickable_header: true, card_body_p_x: "py-0 my-0" do %>
                   <div class="w-100 d-flex align-items-center" data-action="click->render-itinerary-in-user-show-page#renderItineraryPartial">
                     <div><%= "Trip to #{itinerary.destination.city}" %></div>
                     <% if Permission.find_by(user: current_user, itinerary: itinerary).role == "guest" %>


### PR DESCRIPTION
previously, the 'remove itinerary' option appeared after every passenger group on the flight cards in the user show page. 

Flight cards now updated to improve spacing between the passenger groups, and to move the 'delete' option to the bottom of the card only. 

![image](https://user-images.githubusercontent.com/101105112/190926749-07e7d2ea-024f-4b9c-93a3-3531471922fb.png)
