### PR TITLE
Clearer css for small flight card

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -21,6 +21,10 @@ $headers-font: "Nunito", "Helvetica", "sans-serif";
 .text-sm {
   font-size: 12px;
 }
+
+.text-xsm {
+  font-size: 10px;
+}
 // To use a font file (.woff) uncomment following lines
 // @font-face {
 //   font-family: "Font Name";

--- a/app/assets/stylesheets/pages/_user_show.scss
+++ b/app/assets/stylesheets/pages/_user_show.scss
@@ -217,18 +217,24 @@ height: 85vh !important;
   // }
 }
 
-.dotted-line-down {
+.line {
   position: absolute;
   height: 100%;
   left: -35px;
+}
+
+.line-down {
   bottom: -60%;
+}
+
+.line-green {
   border-left: 2px dotted $green;
 }
 
-.dotted-line-up {
-  position: absolute;
-  height: 100%;
-  left: -35px;
-  top: -50%;
+.line-up {
+  top: -60%;
+}
+
+.line-blue {
   border-left: 2px dotted $blue;
 }

--- a/app/views/users/_flight_info.html.erb
+++ b/app/views/users/_flight_info.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="border rounded p-1 <%=mb_x%> shadow bg-white">
   <p class="border-bottom text-success ">
     Flight from <strong class="text-primary"><%=f["departure_city"]%></strong> to <strong class="text-primary"><%=f["arrival_city"]%></strong>
   </p>

--- a/app/views/users/_small_flight_info_card.html.erb
+++ b/app/views/users/_small_flight_info_card.html.erb
@@ -38,7 +38,7 @@
 
           <button class="circle-booking me-3"><i class="fa-solid fa-plane text-white fa-rotate-90"></i></button>
 
-        <div class="small-card-overview-info p-3">
+        <div class="small-card-overview-info p-3 bg-success">
         <div class="dotted-line-down"></div>
           <% bookings = group.bookings.filter {|b| b.status == "confirmed" } %>
           <div class="card-departure-info">
@@ -51,9 +51,10 @@
               </div>
             <% else %>
               <% if bookings.first.offer["flights_there"].count >= 1 %>
-                <% bookings.first.offer["flights_there"].each do |f| %>
-                  <%= render partial: 'users/flight_info', locals: {f: f }%>
+                <% bookings.first.offer["flights_there"][0..-2].each do |f| %>
+                  <%= render partial: 'users/flight_info', locals: {f: f, mb_x: "mb-3" }%>
                 <% end %>
+                <%= render partial: 'users/flight_info', locals: {f: bookings.first.offer["flights_there"].last, mb_x: "" }%>
               <% end %>
             <% end %>
           </div>
@@ -70,7 +71,7 @@
             <div class="small-cards-return">
               <div class="small-card-booking py-3">
                 <button class="circle-booking-up me-3"><i class="fa-solid fa-plane text-white fa-rotate-90"></i></button>
-                <div class="small-card-overview-info-return p-3">
+                <div class="small-card-overview-info-return p-3 bg-primary">
                 <div class="dotted-line-up"></div>
                   <div class="card-departure-info">
                     <% if bookings.empty? %>
@@ -81,9 +82,10 @@
                         <% end %>
                       </div>
                     <% else %>
-                      <% bookings.first.offer["flights_return"].each do |f| %>
-                        <%= render partial: 'users/flight_info', locals: {f: f }%>
+                      <% bookings.first.offer["flights_return"][0..-2].each do |f| %>
+                        <%= render partial: 'users/flight_info', locals: { f: f, mb_x: "mb-3" }%>
                       <% end %>
+                      <%= render partial: 'users/flight_info', locals: { f: bookings.first.offer["flights_return"].last, mb_x: "" }%>
                     <% end %>
                   </div>
                 </div>

--- a/app/views/users/_small_flight_info_card.html.erb
+++ b/app/views/users/_small_flight_info_card.html.erb
@@ -39,7 +39,7 @@
           <button class="circle-booking me-3"><i class="fa-solid fa-plane text-white fa-rotate-90"></i></button>
 
         <div class="small-card-overview-info p-3 bg-success">
-        <div class="dotted-line-down"></div>
+        <div class="line line-down line-green"></div>
           <% bookings = group.bookings.filter {|b| b.status == "confirmed" } %>
           <div class="card-departure-info">
             <% if bookings.empty? %>
@@ -72,7 +72,7 @@
               <div class="small-card-booking py-3">
                 <button class="circle-booking-up me-3"><i class="fa-solid fa-plane text-white fa-rotate-90"></i></button>
                 <div class="small-card-overview-info-return p-3 bg-primary">
-                <div class="dotted-line-up"></div>
+                <div class="line line-up line-blue"></div>
                   <div class="card-departure-info">
                     <% if bookings.empty? %>
                       <div class="d-flex justify-content-between align-items-center">

--- a/app/views/users/sessions/_single_trip_info.html.erb
+++ b/app/views/users/sessions/_single_trip_info.html.erb
@@ -3,7 +3,7 @@
 
 <% PassengerGroup.order_by_flight_info(itinerary.passenger_groups).each do |group| %>
 
-  <div class="card-overview-info mb-3">
+  <div class="card-overview-info mt-3">
     <div class="border-bottom border-success origin-city d-flex justify-content-between align-items-bottom">
       <div>Travellers from <span class="text-primary"><strong><%= group.origin_city.city %></strong></span></div>
       <div>
@@ -21,11 +21,15 @@
       <%= render 'shared/collapsible_section', section_title: 'Getting there', section_partial: 'users/sessions/flight_leg', section_partial_params: { flights: info.first.offer["flights_there"], status: "confirmed" }, collapsed: true, bg_collapsed: 'bg-primary', bg_open: 'bg-secondary', p_x: 'p-0' %>
       <%= render 'shared/collapsible_section', section_title: 'Coming home', section_partial: 'users/sessions/flight_leg', section_partial_params: { flights: info.first.offer["flights_return"], status: "confirmed" }, collapsed: true, text_collapsed: 'text-primary', bg_collapsed: 'border border-primary', text_open: 'text-white', bg_open: 'bg-secondary', p_x: 'p-0' %>
     <% end %>
-    <div class="d-flex justify-content-between">
-      <%= link_to itinerary_path(itinerary), class: "btn btn-link text-secondary text-decoration-none" do %>
+    <div class="d-flex justify-content-between border-bottom">
+      <%= link_to itinerary_path(itinerary), class: "p-0 m-0 w-100 text-end text-xsm btn btn-link text-secondary text-decoration-none" do %>
         <i class="fas fa-search"></i> <%= info.empty? ? "Choose flights" : "Change flights" %>
       <% end %>
-      <% if owner %>
+    </div>
+  </div>
+<% end %>
+<div class="text-start">
+ <% if owner %>
         <%= link_to itinerary_path(itinerary), data: { turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-link text-secondary text-decoration-none" do %>
           <i class="fas fa-ban"></i> Delete itinerary
         <% end %>
@@ -33,8 +37,5 @@
         <%= link_to permission_path(permission), data: { turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-link text-secondary text-decoration-none" do %>
           <i class="fas fa-ban"></i> Remove itinerary
         <% end %>
-      <% end %>
-    </div>
-
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,7 +18,7 @@
                   <div class="w-100 d-flex align-items-center" data-action="click->render-itinerary-in-user-show-page#renderItineraryPartial">
                     <div><%= "Trip to #{itinerary.destination.city}" %></div>
                     <% if Permission.find_by(user: current_user, itinerary: itinerary).role == "guest" %>
-                      <div class="text-sm p-1 rounded bg-primary text-white">Shared with you</div>
+                      <div class="ms-3 text-sm p-1 rounded bg-primary text-white">Shared with you</div>
                     <% end %>
                   </div>
               <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,7 @@
               <div class="d-none itinerary">
                 <%=itinerary.id%>
               </div>
-              <%= render 'shared/collapsible_section', section_partial: 'users/sessions/single_trip_info', section_partial_params: { itinerary: itinerary }, collapsed: collapsed, clickable_header: true do %>
+              <%= render 'shared/collapsible_section', section_partial: 'users/sessions/single_trip_info', section_partial_params: { itinerary: itinerary }, collapsed: collapsed, clickable_header: true, card_body_p_x: "py-0 my-0" do %>
                   <div class="w-100 d-flex align-items-center" data-action="click->render-itinerary-in-user-show-page#renderItineraryPartial">
                     <div><%= "Trip to #{itinerary.destination.city}" %></div>
                     <% if Permission.find_by(user: current_user, itinerary: itinerary).role == "guest" %>


### PR DESCRIPTION
Previously, the css for the small flight info card on the right pane of the user show page (where we see the airplane path) was difficult to read, as the legs of a set of flights were listed one below the other without spacing or borders. 
![image](https://user-images.githubusercontent.com/101105112/190926807-a72525c8-ab67-43aa-8ecd-7d79d0f77189.png)
To improve this, I have now changed the CSS as follows:
![image](https://user-images.githubusercontent.com/101105112/190926852-aee69ae0-bae1-413f-8dc7-0bcc91a790dd.png)

