### PR TITLE
adjusted the flex box so flexible date text has more space

### DIFF
--- a/app/views/itineraries/_dates_form.html.erb
+++ b/app/views/itineraries/_dates_form.html.erb
@@ -4,8 +4,8 @@
       <div class="px-3 w-80 border-end">
         <%= render 'shared/fixed_date_form' %>
       </div>
-      <div class="px-3 w-20">
-        <div class="d-flex justify-content-between h-100">
+      <div class="ps-1 w-20">
+        <div class="d-flex flex-column justify-content-between h-50">
           <i class="fas fa-angle-double-left clickable" data-action="click->search-form#revealDateRangeForm"></i>
           <div class = "d-flex flex-column align-items-center justify-content-center"><em style = "font-size: 0.9vw;">I'm flexible!</em></div>
         </div>
@@ -13,10 +13,10 @@
     </div>
     <div data-search-form-target="flexibleDateForm" class = "d-flex w-50 <%= ((!params[:start_date_range]) || params[:start_date_range].empty?) ? "v-none" : ""%>">
 
-      <div class="px-3 w-20">
-        <div class="d-flex justify-content-between">
-          <div><em style = "font-size: 0.9vw;">Fixed Dates</em></div>
+      <div class="pe-1 w-20">
+        <div class="d-flex flex-column justify-content-between h-50">
           <i class="fas fa-angle-double-right clickable" data-action="click->search-form#revealFixedDateForm"></i>
+          <div><em style = "font-size: 0.9vw;">Fixed Dates</em></div>
         </div>
       </div>
       <div class="px-3 w-80" >


### PR DESCRIPTION
- text in dates form for 'i'm flexible' was cut off inthe itinerary index page
- adjusted flex box to flex on column instead of row & adjusted padding to allow more space for the text